### PR TITLE
Project rename to MBARI WEC

### DIFF
--- a/docs/docs/Tutorials/Install/Install_source.md
+++ b/docs/docs/Tutorials/Install/Install_source.md
@@ -2,7 +2,7 @@
 Use Ubuntu 22.04.
 
 1. Install [ROS 2 Humble](https://docs.ros.org/en/humble/index.html)
-    Buoy Sim is tested against the cyclonedds rmw implementation, so set that up as follows:
+    MBARI WEC is tested against the cyclonedds rmw implementation, so set that up as follows:
         ```
         sudo apt install -y ros-humble-rmw-cyclonedds-cpp
         export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp


### PR DESCRIPTION
Buoy Sim -> MBARI WEC
Didn't find any other instances of the old name. Any new dev should address the project as MBARI WEC.
