### PR TITLE
Automate docker image build and push to dockerhub

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -1,0 +1,46 @@
+name: Build and Push Docker image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: mbari/mbari_wec
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/nvidia_opengl_ubuntu22
+          file: ./docker/nvidia_opengl_ubuntu22/Dockerfile
+          push: false
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/mbari_wec
+          file: ./docker/mbari_wec/Dockerfile
+          build-args: base=nvidia_opengl_ubuntu22:latest
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -24,9 +24,11 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: mbari/mbari_wec
+          flavor: |
+            latest=true
+            suffix='-rc',onlatest=true
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
 
       - name: Build Docker image
         uses: docker/build-push-action@v2
@@ -43,4 +45,3 @@ jobs:
           build-args: base=nvidia_opengl_ubuntu22:latest
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adding Github action workflow to automatically upload mbari_wec docker image to [mbari_wec docker repository](https://hub.docker.com/repository/docker/mbari/mbari_wec/general). This would be triggered when a new tag on this repository is created.

- Need help with adding secrets on this repo for this to work. Mainly dockerhun username and password, steps [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets).
- The default base is `nvidia_opengl_ubuntu22`, is that what we want?
- I haven't tested it yet, should we try the candidate release with this script? Or open to suggestions how I can test it