### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,6 @@ At the moment, MBARI WEC is supported by source installation only. Use Ubuntu Ja
     export GZ_VERSION=garden
     ```
 
-1. Set `SDF_PATH` to allow `robot_state_publisher` parse the robot description from the sdformat model:
-
-   ```
-   export SDF_PATH=$GZ_SIM_RESOURCE_PATH
-   ```
-
 1. Install ROS dependencies
 
     ```
@@ -191,7 +185,13 @@ This sources the compiled workspace and launches the simulation:
 1. In a new terminal (whether on host machine or in Docker container), source the workspace
 
    ```
-   . ~/mbari_wec_ws/install/setup.sh
+   . ~/mbari_wec_ws/install/setup.bash
+   ```
+
+1. Set `SDF_PATH` to allow `robot_state_publisher` to parse the robot description from the sdformat model:
+
+   ```
+   export SDF_PATH=$GZ_SIM_RESOURCE_PATH
    ```
 
 1. Launch the simulation

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ At the moment, MBARI WEC is supported by source installation only. Use Ubuntu Ja
     export GZ_VERSION=garden
     ```
 
+1. Set `SDF_PATH` to allow `robot_state_publisher` parse the robot description from the sdformat model:
+
+   ```
+   export SDF_PATH=$GZ_SIM_RESOURCE_PATH
+   ```
+
 1. Install ROS dependencies
 
     ```

--- a/docker/mbari_wec/Dockerfile
+++ b/docker/mbari_wec/Dockerfile
@@ -119,12 +119,14 @@ RUN /bin/bash -c 'source /opt/ros/humble/setup.bash \
 ENV SETUP_SH /home/$USERNAME/setup.bash
 RUN touch ${SETUP_SH} \
  && chmod 755 ${SETUP_SH} \
- && echo ". ${MBARI_WEC_WS}/install/setup.bash" >> ${SETUP_SH}
+ && echo ". ${MBARI_WEC_WS}/install/setup.bash" >> ${SETUP_SH} \
+ && echo "export SDF_PATH=\$GZ_SIM_RESOURCE_PATH" >> ${SETUP_SH}
 ENV RUN_SH /home/$USERNAME/run_simulation.bash
 RUN touch ${RUN_SH} \
  && chmod 755 ${RUN_SH} \
  && echo ". ${MBARI_WEC_WS}/install/setup.bash" >> ${RUN_SH} \
+ && echo "export SDF_PATH=\$GZ_SIM_RESOURCE_PATH" >> ${RUN_SH} \
  && echo "ros2 launch buoy_gazebo mbari_wec.launch.py" >> ${RUN_SH}
 
 # Start the container at a bash prompt
-ENTRYPOINT ["/bin/bash" , "-c" , "source ${MBARI_WEC_WS}/install/setup.bash && /bin/bash"]
+ENTRYPOINT ["/bin/bash" , "-c", "source $SETUP_SH && /bin/bash"]

--- a/docker/mbari_wec/Dockerfile
+++ b/docker/mbari_wec/Dockerfile
@@ -124,9 +124,8 @@ RUN touch ${SETUP_SH} \
 ENV RUN_SH /home/$USERNAME/run_simulation.bash
 RUN touch ${RUN_SH} \
  && chmod 755 ${RUN_SH} \
- && echo ". ${MBARI_WEC_WS}/install/setup.bash" >> ${RUN_SH} \
- && echo "export SDF_PATH=\$GZ_SIM_RESOURCE_PATH" >> ${RUN_SH} \
+ && echo ". ${SETUP_SH}" >> ${RUN_SH} \
  && echo "ros2 launch buoy_gazebo mbari_wec.launch.py" >> ${RUN_SH}
 
 # Start the container at a bash prompt
-ENTRYPOINT ["/bin/bash" , "-c", "source $SETUP_SH && /bin/bash"]
+ENTRYPOINT ["/bin/bash" , "-c", "source ${SETUP_SH} && /bin/bash"]

--- a/docs/docs/Tutorials/Install/Install_docker.md
+++ b/docs/docs/Tutorials/Install/Install_docker.md
@@ -64,7 +64,7 @@ This sources the compiled workspace and launches the simulation:
 
 1. In a new terminal (whether on host machine or in Docker container), source the workspace
         ```
-        . ~/mbari_wec_ws/install/setup.sh
+        . ~/mbari_wec_ws/install/setup.bash
         ```
 
 1. Launch the simulation

--- a/docs/docs/Tutorials/Install/Install_source.md
+++ b/docs/docs/Tutorials/Install/Install_source.md
@@ -47,13 +47,7 @@ Use Ubuntu 22.04.
         export GZ_VERSION=garden
         ```
 
-4. Set `SDF_PATH` to allow `robot_state_publisher` parse the robot description
-   from the sdformat model (place this in ~/.bashrc for convenience if rebuilding often):
-       ```
-       export SDF_PATH=$GZ_SIM_RESOURCE_PATH
-       ```
-
-5. Install ROS dependencies
+4. Install ROS dependencies
         ```
         sudo pip3 install -U rosdep
         sudo rosdep init
@@ -61,7 +55,7 @@ Use Ubuntu 22.04.
         rosdep install --from-paths src --ignore-src -r -y -i
         ```
 
-6. Build and install
+5. Build and install
         ```
         source /opt/ros/humble/setup.bash
         cd ~/mbari_wec_ws
@@ -76,8 +70,14 @@ Use Ubuntu 22.04.
 
 1. In a new terminal, source the workspace
         ```
-        . ~/mbari_wec_ws/install/setup.sh
+        . ~/mbari_wec_ws/install/setup.bash
         ```
+
+1. Set `SDF_PATH` to allow `robot_state_publisher` parse the robot description
+   from the sdformat model (place this in ~/.bashrc for convenience if rebuilding often):
+       ```
+       export SDF_PATH=$GZ_SIM_RESOURCE_PATH
+       ```
 
 1. Launch the simulation
         ```

--- a/docs/docs/Tutorials/Install/Install_source.md
+++ b/docs/docs/Tutorials/Install/Install_source.md
@@ -47,7 +47,13 @@ Use Ubuntu 22.04.
         export GZ_VERSION=garden
         ```
 
-4. Install ROS dependencies
+4. Set `SDF_PATH` to allow `robot_state_publisher` parse the robot description
+   from the sdformat model (place this in ~/.bashrc for convenience if rebuilding often):
+       ```
+       export SDF_PATH=$GZ_SIM_RESOURCE_PATH
+       ```
+
+5. Install ROS dependencies
         ```
         sudo pip3 install -U rosdep
         sudo rosdep init
@@ -55,7 +61,7 @@ Use Ubuntu 22.04.
         rosdep install --from-paths src --ignore-src -r -y -i
         ```
 
-5. Build and install
+6. Build and install
         ```
         source /opt/ros/humble/setup.bash
         cd ~/mbari_wec_ws

--- a/docs/docs/Tutorials/Simulation/RunSimulator.md
+++ b/docs/docs/Tutorials/Simulation/RunSimulator.md
@@ -12,7 +12,7 @@ To run the simulator, it is necessary to source the workspace in a separate term
 
 1. Source the workspace
 ```
-$ . ~/mbari_wec_ws/install/setup.sh
+$ . ~/mbari_wec_ws/install/setup.bash
 ```
 2. Launch the simulation
 ```

--- a/docs/docs/Tutorials/Simulation/SimulatorOutputPlotjuggler.md
+++ b/docs/docs/Tutorials/Simulation/SimulatorOutputPlotjuggler.md
@@ -6,7 +6,7 @@
 ## Installation and Running
 - To install, see instructions [here](https://index.ros.org/p/plotjuggler/).  If using the supplied docker images, this step is not necessary as the software is already installed.
 
-- To start, issue the following command in a window where the environment has already been sourced using ```$ . ~/mbari_wec_ws/install/setup.sh```:
+- To start, issue the following command in a window where the environment has already been sourced using ```$ . ~/mbari_wec_ws/install/setup.bash```:
 
 ```
 $ ros2 run plotjuggler plotjuggler 

--- a/docs/docs/Tutorials/Simulation/SimulatorOutputROS.md
+++ b/docs/docs/Tutorials/Simulation/SimulatorOutputROS.md
@@ -1,6 +1,6 @@
 # View ROS 2 Messages
 
-While running, the simulator generates exactly the same ROS 2 messages that the buoy hardware does during operation.  These are grouped into ROS 2 topics that corresponds to data being produced by each micro-controller or instrument on the buoy.  To see all ROS 2 topics being published to on the system, issue the following command (after sourcing the workspace if needed in a new terminal ``` $ . ~/mbari_wec_ws/install/setup.sh```
+While running, the simulator generates exactly the same ROS 2 messages that the buoy hardware does during operation.  These are grouped into ROS 2 topics that corresponds to data being produced by each micro-controller or instrument on the buoy.  To see all ROS 2 topics being published to on the system, issue the following command (after sourcing the workspace if needed in a new terminal ``` $ . ~/mbari_wec_ws/install/setup.bash```
 
 ``` 
 $ ros2 topic list 


### PR DESCRIPTION
Related to https://github.com/osrf/mbari_wec_gz/issues/95

Setting an environment variable `SDF_PATH` avoids robot_state_publisher showing errors while running the main launch file. 

Note, this does not affect the sim running by default but throws errors (like in the tagged issue) which can be confusing. 

There's an open PR in sdformat_urdf to handle mode:// paths which would be extended to parse package:// paths as well (yet to confirm that). But until then, this step is necessary to run RViz alongside the sim.

Just added it in the build instructions, shall I add it in the `SETUP_SH` in the dockerfile as well?