### PR TITLE
Changed to FSHydro Version 1.3.0 in Readme and Tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ At the moment, MBARI WEC is supported by source installation only. Use Ubuntu Ja
     curl -s --compressed "https://hamilton8415.github.io/ppa/KEY.gpg" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ppa.gpg >/dev/null
     sudo curl -s --compressed -o /etc/apt/sources.list.d/my_list_file.list "https://hamilton8415.github.io/ppa/my_list_file.list"
     sudo apt update
-    sudo apt install libfshydrodynamics=1.2.3
+    sudo apt install libfshydrodynamics=1.3.0
     ```
 
 

--- a/docs/docs/Tutorials/Install/Install_source.md
+++ b/docs/docs/Tutorials/Install/Install_source.md
@@ -22,7 +22,7 @@ Use Ubuntu 22.04.
         curl -s --compressed "https://hamilton8415.github.io/ppa/KEY.gpg" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/ppa.gpg >/dev/null
         sudo curl -s --compressed -o /etc/apt/sources.list.d/my_list_file.list "https://hamilton8415.github.io/ppa/my_list_file.list"
         sudo apt update
-        sudo apt install libfshydrodynamics=1.2.3
+        sudo apt install libfshydrodynamics=1.3.0
         ```
 
 

--- a/docs/docs/Tutorials/Simulation/SimulatorParameters.md
+++ b/docs/docs/Tutorials/Simulation/SimulatorParameters.md
@@ -57,9 +57,9 @@ IncidentWaveSpectrumType:
      # Hs & Tp may be vector/scalar in pairs (Hs & Tp same length)
      Hs: 3.0
      Tp: 14.0
- # Multiple Custom Spectra must be listed individually (w & Szz are already vectors of same size)
+ # Multiple Custom Spectra must be listed individually (f & Szz are already vectors of same size)
  - Custom:
-     w: [0.0, 0.2, 0.4, 0.6, 2.0]
+     f: [0.0, 0.2, 0.4, 0.6, 2.0]
      Szz: [0.0, 0.4, 1.0, 1.0, 0.0]
 ```
 


### PR DESCRIPTION
Changes documentation to use fs-hydro library version 1.3.0.  There is an associated PR in mbari_wec_gz that should be merged along with this one.