### PR TITLE
Update mbari_wec_all.yaml

### DIFF
--- a/mbari_wec_all.yaml
+++ b/mbari_wec_all.yaml
@@ -17,8 +17,9 @@ repositories:
   ros_gz:
     type: git
     url: https://github.com/gazebosim/ros_gz
-    version: 7c62a1ce3cfb4eb3b54e1cfd092c9b63a9d5f255
+    version: humble
+    # version: 7c62a1ce3cfb4eb3b54e1cfd092c9b63a9d5f255
   sdformat_urdf:
     type: git
     url: https://github.com/ros/sdformat_urdf
-    version: ros2
+    version: humble


### PR DESCRIPTION
ros2 branch in sdformat_urdf was deleted and error was captured in nightly build

updating sdformat_urdf:
https://github.com/ros/sdformat_urdf/tree/humble

updating ros_gz:
https://github.com/gazebosim/ros_gz/tree/humble
