### PR TITLE
development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is the entrypoint for the wave energy harvesting buoy project.
 
-See [documentation here](https://osrf.github.io/mbari_wec/main/).
+See [documentation here](https://osrf.github.io/mbari_wec/dev/).
 
 And MBARI-WEC in action using Gazebo simulator here:
 
@@ -11,18 +11,18 @@ And MBARI-WEC in action using Gazebo simulator here:
 
 These are the repositories for the project:
 
-* [mbari_wec_utils](https://github.com/osrf/mbari_wec_utils/tree/main): ROS 2 messages, interface API, and examples for
+* [mbari_wec_utils](https://github.com/osrf/mbari_wec_utils/tree/dev): ROS 2 messages, interface API, and examples for
   receiving and sending data to a physical or simulated buoy.
-    * [buoy_interfaces](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp): ROS 2 messages
+    * [buoy_interfaces](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp): ROS 2 messages
       to recieve and send data to a physical or simulated buoy
-    * [buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp): C++ Interface to
+    * [buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp): C++ Interface to
       MBARI Power Buoy including Controller examples to run against a physical or simulated buoy.
-    * [buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_py): Python Interface to
+    * [buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_py): Python Interface to
       MBARI Power Buoy including Controller examples to run against a physical or simulated buoy.
-* [mbari_wec_gz](https://github.com/osrf/mbari_wec_gz/tree/main)
-    * [buoy_description](https://github.com/osrf/mbari_wec_gz/tree/main/buoy_description):
+* [mbari_wec_gz](https://github.com/osrf/mbari_wec_gz/tree/dev)
+    * [buoy_description](https://github.com/osrf/mbari_wec_gz/tree/dev/buoy_description):
       Buoy model description.
-    * [buoy_gazebo](https://github.com/osrf/mbari_wec_gz/tree/main/buoy_gazebo):
+    * [buoy_gazebo](https://github.com/osrf/mbari_wec_gz/tree/dev/buoy_gazebo):
       Gazebo plugins, worlds and launch files to simulate the buoy.
 
 # Interfaces and Examples
@@ -31,10 +31,10 @@ There are two GitHub
 [template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)
 repositories set up (cpp/python) for a quick start on writing a
 custom controller utilizing
-[buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp) and
-[buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_py). Please see
-[cpp examples](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp/examples) and
-[python examples](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_py/buoy_api/examples) for example
+[buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp) and
+[buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_py). Please see
+[cpp examples](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp/examples) and
+[python examples](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_py/buoy_api/examples) for example
 controller implementations.
 
 * [mbari_wec_template_cpp](https://github.com/mbari-org/mbari_wec_template_cpp)
@@ -46,15 +46,15 @@ At the moment, MBARI WEC is supported by source and Docker installation only.
 
 ### Source Install On Host System
 
-[Tutorial: Install from source](https://osrf.github.io/mbari_wec/main/Tutorials/Install/Install_source/#install-from-source)
+[Tutorial: Install from source](https://osrf.github.io/mbari_wec/dev/Tutorials/Install/Install_source/#install-from-source)
 
 ### Using Docker
 
-[Tutorial: Install using Docker](https://osrf.github.io/mbari_wec/main/Tutorials/Install/Install_docker/#install-using-docker)
+[Tutorial: Install using Docker](https://osrf.github.io/mbari_wec/dev/Tutorials/Install/Install_docker/#install-using-docker)
 
 # Run the Simulator
 
-[Tutorial: Running the Simulator](https://osrf.github.io/mbari_wec/main/Tutorials/Simulation/RunSimulator/#running-the-simulator)
+[Tutorial: Running the Simulator](https://osrf.github.io/mbari_wec/dev/Tutorials/Simulation/RunSimulator/#running-the-simulator)
 
 # For maintainers only: To upload to DockerHub
 

--- a/docker/mbari_wec/Dockerfile
+++ b/docker/mbari_wec/Dockerfile
@@ -102,7 +102,7 @@ RUN ls
 ENV MBARI_WEC_WS /home/$USERNAME/mbari_wec_ws
 RUN mkdir -p ${MBARI_WEC_WS}/src \
  && cd ${MBARI_WEC_WS}/src/ \
- && wget https://raw.githubusercontent.com/osrf/mbari_wec/main/mbari_wec_all.yaml \
+ && wget https://raw.githubusercontent.com/osrf/mbari_wec/dev/mbari_wec_all.yaml \
  && cat mbari_wec_all.yaml
 
 RUN cd ${MBARI_WEC_WS}/src \

--- a/docs/docs/ROS2/messages.md
+++ b/docs/docs/ROS2/messages.md
@@ -1,7 +1,7 @@
 # Buoy Interfaces (ROS 2 Messages)
 
 Several ROS 2 messages/services have been defined in the
-[buoy_interfaces](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_interfaces) package to
+[buoy_interfaces](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_interfaces) package to
 access telemetry and send commands.
 
 For more information about ROS 2 interfaces, see

--- a/docs/docs/Tutorials/Install/Install_docker.md
+++ b/docs/docs/Tutorials/Install/Install_docker.md
@@ -23,12 +23,12 @@ MBARI maintains Docker images for the two most recent releases on their DockerHu
 
 1. Get `run.bash` script.
    ```
-   git clone -b main https://github.com/osrf/mbari_wec.git
+   git clone -b dev https://github.com/osrf/mbari_wec.git
    cd ~/mbari_wec/docker/
    ```
    Or
    ```
-   wget https://raw.githubusercontent.com/osrf/mbari_wec/main/docker/run.bash
+   wget https://raw.githubusercontent.com/osrf/mbari_wec/dev/docker/run.bash
    chmod +x run.bash
    ```
 
@@ -53,7 +53,7 @@ is convenient if you would like to make any changes.
 
 1. Clone the mbari_wec repository to download the latest Dockerfile.
    ```
-   git clone -b main https://github.com/osrf/mbari_wec.git
+   git clone -b dev https://github.com/osrf/mbari_wec.git
    cd ~/mbari_wec/docker/
    ```
 

--- a/docs/docs/Tutorials/Install/Install_source.md
+++ b/docs/docs/Tutorials/Install/Install_source.md
@@ -9,8 +9,10 @@
 
 Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/harmonic/ros_installation/).
 
-1. [Install](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html) ROS 2 Jazzy
+1. Go to the following to [Install](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html) ROS 2 Jazzy, if you do not already have it installed on your machine.
 
+    Following your ROS installation do the following:
+   
     MBARI WEC works best with the cyclonedds rmw implementation, so set that up as follows:
    
     ```
@@ -18,11 +20,11 @@ Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/
     export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     ```
 
-    Running the sim with rosbag2 logging uses mcap storage. We also need sdformat-urdf.
+    Running the sim with rosbag2 logging uses mcap storage. We also need sdformat-urdf and tf_transformations.
     So, install those as well:
 
     ```
-    sudo apt install ros-jazzy-rosbag2-storage-mcap ros-jazzy-sdformat-urdf
+    sudo apt install ros-jazzy-rosbag2-storage-mcap ros-jazzy-sdformat-urdf ros-jazzy-tf-transformations
     ```
 
     To use plotjuggler to view ros2 data live plots (recommended in these tutorials), install like so:
@@ -48,7 +50,13 @@ Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/
     export GZ_VERSION=harmonic
     ```
 
-4. gz-python-bindings
+4. Install necessary tools
+   
+    ```
+    sudo apt install python3-vcstool python3-colcon-common-extensions python3-pip git wget
+    ```
+
+5. gz-python-bindings
 
     Python bindings for `gz.math` and `gz.sim` are used in `mbari_wec` but are not distributed via apt or pip.
     This repository, [gz-python-bindings](https://github.com/mbari-org/gz-python-bindings) builds the python
@@ -68,12 +76,6 @@ Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/
         ```
         python3 -m pip install -i https://mbari-org.github.io/gz-python-bindings/simple gz-python-bindings --break-system-packages
         ```
-
-5. Install necessary tools
-   
-    ```
-    sudo apt install python3-vcstool python3-colcon-common-extensions python3-pip git wget
-    ```
 
 6. Install necessary libraries
    
@@ -103,6 +105,8 @@ Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/
     ```
 
 3. Install ROS dependencies
+
+    NOTE: do not be alarmed if you recieve "error: externally managed environment" following the first line here
    
     ```
     sudo pip3 install -U rosdep
@@ -133,10 +137,10 @@ Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/
 
 2. Set `SDF_PATH` to allow `robot_state_publisher` parse the robot description
    from the sdformat model (place this in ~/.bashrc for convenience if rebuilding often):
-
-   ```
-   export SDF_PATH=$GZ_SIM_RESOURCE_PATH
-   ```
+   
+    ```
+    export SDF_PATH=$GZ_SIM_RESOURCE_PATH
+    ```
 
 3. Launch the simulation
    
@@ -145,8 +149,7 @@ Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/
     ```
 
 ## Post-Build Environment Setup
-
-Place these lines in your ~/.bashrc for convenience to simplify running the sim in the future:
+1. Place these lines in your ~/.bashrc for convenience to simplify running the sim in the future:
    
     ```
     source /opt/ros/jazzy/setup.bash

--- a/docs/docs/Tutorials/Install/Install_source.md
+++ b/docs/docs/Tutorials/Install/Install_source.md
@@ -97,7 +97,7 @@ Follow instructions for [Installing Gazebo with ROS](https://gazebosim.org/docs/
 2. Clone all source repos with the help of `vcstool`:
    
     ```
-    wget https://raw.githubusercontent.com/osrf/mbari_wec/main/mbari_wec_all.yaml
+    wget https://raw.githubusercontent.com/osrf/mbari_wec/dev/mbari_wec_all.yaml
     vcs import < mbari_wec_all.yaml
     cd ~/mbari_wec_ws
     ```

--- a/docs/docs/Tutorials/ROS2/CppLinearDamperExample.md
+++ b/docs/docs/Tutorials/ROS2/CppLinearDamperExample.md
@@ -241,7 +241,7 @@ reduced when retracting.
 ### Controller
 
 All that is left is to connect the necessary feedback data to the `ControlPolicy`. In this case,
-`rpm`, `scale`, and `retract` are present in [`buoy_interfaces.msg.PCRecord`](https://github.com/osrf/mbari_wec_utils/blob/main/buoy_interfaces/msg/PCRecord.msg) on the `/power_data`
+`rpm`, `scale`, and `retract` are present in [`buoy_interfaces.msg.PCRecord`](https://github.com/osrf/mbari_wec_utils/blob/dev/buoy_interfaces/msg/PCRecord.msg) on the `/power_data`
 topic published by the Power Controller running on the buoy.
 
 To access the data, all that is required is to define the callback

--- a/docs/docs/Tutorials/ROS2/CppTemplate.md
+++ b/docs/docs/Tutorials/ROS2/CppTemplate.md
@@ -11,10 +11,10 @@ There are two GitHub
 [template repositories](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)
 set up (C++/Python) for a quick start on writing a
 custom controller utilizing
-[buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp) and
-[buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_py). Please see
-[C++ examples](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp/examples) and
-[Python examples](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_py/buoy_api/examples) for
+[buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp) and
+[buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_py). Please see
+[C++ examples](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp/examples) and
+[Python examples](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_py/buoy_api/examples) for
 example controller implementations.
 
 * [mbari_wec_template_cpp](https://github.com/mbari-org/mbari_wec_template_cpp)

--- a/docs/docs/Tutorials/ROS2/PythonTemplate.md
+++ b/docs/docs/Tutorials/ROS2/PythonTemplate.md
@@ -11,10 +11,10 @@ There are two GitHub
 [template repositories](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)
 set up (C++/Python) for a quick start on writing a
 custom controller utilizing
-[buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp) and
-[buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_py). Please see
-[C++ examples](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_cpp/examples) and
-[Python examples](https://github.com/osrf/mbari_wec_utils/tree/main/buoy_api_py/buoy_api/examples) for example
+[buoy_api_cpp](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp) and
+[buoy_api_py](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_py). Please see
+[C++ examples](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_cpp/examples) and
+[Python examples](https://github.com/osrf/mbari_wec_utils/tree/dev/buoy_api_py/buoy_api/examples) for example
 controller implementations.
 
 * [mbari_wec_template_cpp](https://github.com/mbari-org/mbari_wec_template_cpp)

--- a/docs/docs/Tutorials/Simulation/SimulatorOutputPlotjuggler.md
+++ b/docs/docs/Tutorials/Simulation/SimulatorOutputPlotjuggler.md
@@ -16,7 +16,7 @@ $ ros2 run plotjuggler plotjuggler
 
 
 ## Plotting Wave Energy Converter Data
-In the window on the left that shows the available topics, select the /arhs_data, /power_data, /spring_data, battery_data, heavecone_data and /xb_data topics and click "OK".  Note that for these topics to be available, the simulation needs to be running.
+In the window on the left that shows the available topics, select the /arhs_data, /power_data, /spring_data, /battery_data, /trefoil_data and /latent_data topics and click "OK".  Note that for these topics to be available, the simulation needs to be running.
 
 - The selected topics will appear in the "Timeseries List" window, and selecting the carrot to the left of each topic will expand them and show the data that can be plotted.  Note that these topics and data are the same as are visible using the ```$ ros2 topic list``` and ```$ ros2 topic echo``` commands from the command-line.
 

--- a/mbari_wec_all.yaml
+++ b/mbari_wec_all.yaml
@@ -3,12 +3,12 @@ repositories:
   mbari_wec:
     type: git
     url: https://github.com/osrf/mbari_wec
-    version: main
+    version: dev
   mbari_wec_utils:
     type: git
     url: https://github.com/osrf/mbari_wec_utils
-    version: main
+    version: dev
   mbari_wec_gz:
     type: git
     url: https://github.com/osrf/mbari_wec_gz
-    version: main
+    version: dev


### PR DESCRIPTION
The goal is to leave `main` in the latest known good state and insulate it from continued, unstable development in the `dev` branch. New feature branches will branch from and merge to `dev` rather than `main` (in most cases). For a new release, `dev` will be merged to `main` and a release will be published from `main` as before.

Also, there is now a `dev` version of the documentation at: https://osrf.github.io/mbari_wec/dev/ which will be updated by merging to `dev` just like merging to `main`.

NOTE: Remember to put dev branch references back to main before merging!